### PR TITLE
fix：get_toolset_for_tool error

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -131,6 +131,7 @@ from model_tools import (
     get_tool_definitions,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.get_tool_definitions")
     handle_function_call,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.handle_function_call")
     check_toolset_requirements,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.check_toolset_requirements")
+    get_toolset_for_tool,  # noqa: F401  # re-exported for system_prompt._ra() / mock.patch("run_agent.get_toolset_for_tool")
 )
 from tools.terminal_tool import cleanup_vm
 from tools.interrupt import set_interrupt as _set_interrupt


### PR DESCRIPTION


## Summary

in first , add deepseek-v4 cant not  chat，has  error，module 'run_agent' has no attribute 'get_toolset_for_tool'

## Changes

The module 'run_agent' has no attribute 'get_toolset_for_tool' error was caused by get_toolset_for_tool never being imported into the run_agent namespace, even though agent/system_prompt.py:185 calls it via _r.get_toolset_for_tool(...) and the _ra() docstring at system_prompt.py:45-57 explicitly lists it as one of the helpers imported into run_agent .

The symbol is defined in model_tools.py:1192 , and run_agent.py already re-exports several sibling symbols from model_tools for the same mock.patch contract — I just added get_toolset_for_tool to that existing import block.

## Validation

- [x] I ran the checks relevant to this change.
- [x] I manually checked user-visible behavior when applicable.
- [x] I added a screenshot or recording for visible UI changes, or the change has no visible UI.
- [x] I removed credentials, cookies, tokens, personal data, and private page content from this pull request.

## Notes

`None` 


<img width="1213" height="885" alt="image" src="https://github.com/user-attachments/assets/168583a6-a959-4892-a7f8-a644ad9c5a6a" />